### PR TITLE
Rename certification run CR according to operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
-# CNF Certification Suite Operator's Console Plugin
+# Certification Suite Operator's Console Plugin
 
 [![red hat](https://img.shields.io/badge/red%20hat---?color=gray&logo=redhat&logoColor=red&style=flat)](https://www.redhat.com)
 [![openshift](https://img.shields.io/badge/openshift---?color=gray&logo=redhatopenshift&logoColor=red&style=flat)](https://www.redhat.com/en/technologies/cloud-computing/openshift)
 
 ## Description
 
-The `CNF certsuite plugin` is an
+The `Certsuite plugin` is an
 [openshift dynamic console plugin](https://github.com/openshift/console/tree/master/frontend/packages/console-dynamic-plugin-sdk)
 extending the [OpenShift UI](https://github.com/openshift/console)
-for the CNF Certification Suite Operator.
+for the Certification Suite Operator.
 
 This console plugin allows the possibility to run the
-[CNF certification suites](https://github.com/test-network-function/cnf-certification-test)
+[Certification suites](https://github.com/redhat-best-practices-for-k8s/certsuite)
 and review their results using the openshift console.
 
 ## Getting started
 
-In order to extend the openshift console with the `CNF certsuite plugin`,
+In order to extend the openshift console with the `certsuite plugin`,
 you'll need to install the
-[CNF certification suite operator](https://github.com/test-network-function/cnf-certsuite-operator)
+[certification suite operator](https://github.com/redhat-best-practices-for-k8s/certsuite-operator)
 on your cluster.
 
 ## Enable plugin
 
-After installing the `CNF certification operator`, you might need to enable the plugin.
+After installing the `Certification operator`, you might need to enable the plugin.
 
 ### Option 1: Operator was installed using OLM subscription
 
@@ -50,19 +50,19 @@ you should see a new tab added to the navigation bar:
 <!-- markdownlint-enable-next-line no-inline-html -->
 
 You can add the required resources detailed
-[here](https://github.com/test-network-function/cnf-certsuite-operator?tab=readme-ov-file#how-to-customize-the-cnf-certification-suite-run),
+[here](https://github.com/redhat-best-practices-for-k8s/certsuite-operator?tab=readme-ov-file#how-to-customize-the-certification-suite-run),
 by navigating to the corresponding tabs and using the `create` option.
 
-The CNF certification test results will appear under the
-`CNF certification Suite CR's` corresponding to the created
-cnf certification run CR name.
+The certification test results will appear under the
+`Certification Suite CR's` corresponding to the created
+certification run CR name.
 
 See example:
 
-![cnfCertificationSuiteRun-CR-list](doc/cnfCertificationSuiteRun-CR-list.png)
+![CertificationSuiteRun-CR-list](doc/cnfCertificationSuiteRun-CR-list.png)
 
-Under the `Results` tab you can find the CNF certification suites results.
+Under the `Results` tab you can find the certification suites results.
 
 See example:
 
-![cnfCertificationSuiteRun-results](doc/cnfCertificationSuiteRun-results.png)
+![CertificationSuiteRun-results](doc/cnfCertificationSuiteRun-results.png)

--- a/console-extensions.json
+++ b/console-extensions.json
@@ -2,10 +2,10 @@
   {
     "type": "console.navigation/section",
     "properties": {
-      "id": "cnf-cert-section",
+      "id": "certsuite-section",
       "insertAfter": "builds",
       "perspective": "admin",
-      "name": "Cnf Certification Suites"
+      "name": "Certification Suites"
     }
   },
   {
@@ -14,25 +14,25 @@
         "data-quickstart-id": "qs-nav-templates",
         "data-test-id": "templates-nav-item"
       },
-      "id": "cnfCertificationSuiteRuns",
+      "id": "certsuiteRuns",
       "model": {
-        "group": "cnf-certifications.redhat.com",
-        "kind": "CnfCertificationSuiteRun",
+        "group": "best-practices-for-k8s.openshift.io",
+        "kind": "CertsuiteRun",
         "version": "v1alpha1"
       },
-      "name": "%plugin__certsuite-operator-plugin~Cnf Certification Suite CRs%",
-      "section": "cnf-cert-section"
+      "name": "%plugin__certsuite-operator-plugin~Certification Suite CRs%",
+      "section": "certsuite-section"
     },
     "type": "console.navigation/resource-ns"
   },
   {
     "properties": {
       "component": {
-        "$codeRef": "CnfCertsuiteRunPage"
+        "$codeRef": "CertsuiteRunPage"
       },
       "model": {
-        "group": "cnf-certifications.redhat.com",
-        "kind": "CnfCertificationSuiteRun",
+        "group": "best-practices-for-k8s.openshift.io",
+        "kind": "CertsuiteRun",
         "version": "v1alpha1"
       }
     },
@@ -42,8 +42,8 @@
     "type": "console.tab/horizontalNav",
     "properties": {
       "model": {
-        "group": "cnf-certifications.redhat.com",
-        "kind": "CnfCertificationSuiteRun",
+        "group": "best-practices-for-k8s.openshift.io",
+        "kind": "CertsuiteRun",
         "version": "v1alpha1"
       },
       "page": {
@@ -65,7 +65,7 @@
         "version": "v1"
       },
       "name": "%plugin__certsuite-operator-plugin~Secrets%",
-      "section": "cnf-cert-section"
+      "section": "certsuite-section"
     },
     "type": "console.navigation/resource-ns"
   }
@@ -82,7 +82,7 @@
         "version": "v1"
       },
       "name": "%plugin__certsuite-operator-plugin~ConfigMap%",
-      "section": "cnf-cert-section"
+      "section": "certsuite-section"
     },
     "type": "console.navigation/resource-ns"
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/aabughosh/cnf-plugin"
+    "url": "https://github.com/redhat-best-practices-for-k8s/certsuite-operator-plugin"
   },
   "scripts": {
     "clean": "rm -rf dist",
@@ -71,10 +71,10 @@
   "consolePlugin": {
     "name": "certsuite-operator-plugin",
     "version": "0.0.1",
-    "displayName": "CNF certification test plugin",
+    "displayName": "Certification test plugin",
     "description": "This plugin adds Red Hat best practices for Kubernetes tests suites results to the OpenShift web console.",
     "exposedModules": {
-      "CnfCertsuiteRunPage": "./components/CnfCertsuiteRunPage",
+      "CertsuiteRunPage": "./components/CertsuiteRunPage",
       "ResultsPage": "./components/ResultsPage"
     },
     "dependencies": {

--- a/src/components/CertsuiteRunPage.tsx
+++ b/src/components/CertsuiteRunPage.tsx
@@ -14,14 +14,14 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useTranslation } from 'react-i18next';
 
-type CnfCertificationSuiteRunTableProps = {
+type CertsuiteRunTableProps = {
   data: K8sResourceCommon[];
   unfilteredData: K8sResourceCommon[];
   loaded: boolean;
   loadError: any;
 };
 
-const CnfCertificationSuiteRunTable: React.FC<CnfCertificationSuiteRunTableProps> = ({ data, unfilteredData, loaded, loadError }) => {
+const CertsuiteRunTable: React.FC<CertsuiteRunTableProps> = ({ data, unfilteredData, loaded, loadError }) => {
   const { t } = useTranslation();
 
   const columns: TableColumn<K8sResourceCommon>[] = [
@@ -35,11 +35,11 @@ const CnfCertificationSuiteRunTable: React.FC<CnfCertificationSuiteRunTableProps
     },
   ];
 
-  const CnfCertificationSuiteRunRow: React.FC<RowProps<K8sResourceCommon>> = ({ obj, activeColumnIDs }) => {
+  const CertsuiteRunRow: React.FC<RowProps<K8sResourceCommon>> = ({ obj, activeColumnIDs }) => {
     return (
       <>
         <TableData id={columns[0].id} activeColumnIDs={activeColumnIDs}>
-          <ResourceLink kind="cnf-certifications.redhat.com~v1alpha1~CnfCertificationSuiteRun" name={obj.metadata.name} namespace={obj.metadata.namespace}  />
+          <ResourceLink kind="best-practices-for-k8s.openshift.io~v1alpha1~CertsuiteRun" name={obj.metadata.name} namespace={obj.metadata.namespace}  />
         </TableData>
         <TableData id={columns[1].id} activeColumnIDs={activeColumnIDs}>
           <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
@@ -55,7 +55,7 @@ const CnfCertificationSuiteRunTable: React.FC<CnfCertificationSuiteRunTableProps
       loaded={loaded}
       loadError={loadError}
       columns={columns}
-      Row={CnfCertificationSuiteRunRow}
+      Row={CertsuiteRunRow}
     />
   );
 };
@@ -65,9 +65,9 @@ const ListPage = ({namespace,name}) => {
 
   const [resources, loaded, loadError] = useK8sWatchResource<K8sResourceCommon[]>({
     groupVersionKind: {
-      group: 'cnf-certifications.redhat.com', 
+      group: 'best-practices-for-k8s.openshift.io', 
       version: 'v1alpha1',                         
-      kind: 'CnfCertificationSuiteRun',      
+      kind: 'CertsuiteRun',      
     },
     namespace,
     name,
@@ -77,16 +77,16 @@ const ListPage = ({namespace,name}) => {
 
   return (
     <>
-      <ListPageHeader title={t('plugin__certsuite-operator-plugin~CnfCertificationSuiteRun CRs List')}>
+      <ListPageHeader title={t('plugin__certsuite-operator-plugin~CertsuiteRun CRs List')}>
    
       </ListPageHeader>
       <ListPageHeader title={t('')}>
-      <ListPageCreate groupVersionKind={{ group: 'cnf-certifications.redhat.com', version: 'v1alpha1', kind: 'CnfCertificationSuiteRun' }}>
-          {t('plugin__certsuite-operator-plugin~Create a CnfCertificationSuiteRun CR')}
+      <ListPageCreate groupVersionKind={{ group: 'best-practices-for-k8s.openshift.io', version: 'v1alpha1', kind: 'CertsuiteRun' }}>
+          {t('plugin__certsuite-operator-plugin~Create a CertsuiteRun CR')}
         </ListPageCreate>
       </ListPageHeader>
       <ListPageBody>
-        <CnfCertificationSuiteRunTable
+        <CertsuiteRunTable
           data={resources}
           unfilteredData={resources}
           loaded={loaded}
@@ -94,8 +94,8 @@ const ListPage = ({namespace,name}) => {
         />
       </ListPageBody>
       <ListPageBody>
-        <p>{t('plugin__certsuite-operator-plugin~Sample ResourceIcon for CnfCertificationSuiteRun')}</p>
-        <ResourceIcon kind="CnfCertificationSuiteRun" />
+        <p>{t('plugin__certsuite-operator-plugin~Sample ResourceIcon for CertsuiteRun')}</p>
+        <ResourceIcon kind="CertsuiteRun" />
       </ListPageBody>
     </>
   );

--- a/src/components/ConfigMapList.tsx
+++ b/src/components/ConfigMapList.tsx
@@ -77,7 +77,7 @@ const ListConfigMap = ({namespace,name}) => {
 
   return (
     <>
-      <ListPageHeader title={t('plugin__certsuite-operator-plugin~CnfCertificationSuiteRun ConfigMap List')}>
+      <ListPageHeader title={t('plugin__certsuite-operator-plugin~CertSuiteRun ConfigMap List')}>
       <ListPageCreate groupVersionKind={{version: 'v1', kind: 'ConfigMap' }}>
           {t('plugin__certsuite-operator-plugin~Create a ConfigMap')}
         </ListPageCreate> 

--- a/src/components/ResultsPage.tsx
+++ b/src/components/ResultsPage.tsx
@@ -11,7 +11,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { ProgressBar } from './ProgressBar'; // Import the ProgressBar component
 
-interface CnfCertificationSuiteRun extends K8sResourceCommon {
+interface CertSuiteRun extends K8sResourceCommon {
   status: {
     report: {
       results: Results[];
@@ -34,7 +34,7 @@ interface Results {
   reason?: string;
 }
 
-const columns: TableColumn<CnfCertificationSuiteRun>[] = [
+const columns: TableColumn<CertSuiteRun>[] = [
   {
     title: 'Test Case Name',
     id: 'testCaseName',
@@ -49,7 +49,7 @@ const columns: TableColumn<CnfCertificationSuiteRun>[] = [
   },
 ];
 
-const CnfCertificationSuiteRunRow: React.FC<RowProps<Results>> = ({ obj, activeColumnIDs }) => {
+const CertSuiteRunRow: React.FC<RowProps<Results>> = ({ obj, activeColumnIDs }) => {
   return (
     <>
       <TableData id={columns[0].id} activeColumnIDs={activeColumnIDs}>
@@ -65,7 +65,7 @@ const CnfCertificationSuiteRunRow: React.FC<RowProps<Results>> = ({ obj, activeC
   );
 };
 
-const CnfCertificationSuiteRunTable: React.FC<{ data: Results[]; loaded: boolean; loadError: any }> = ({
+const CertSuiteRunTable: React.FC<{ data: Results[]; loaded: boolean; loadError: any }> = ({
   data,
   loaded,
   loadError,
@@ -76,11 +76,11 @@ const CnfCertificationSuiteRunTable: React.FC<{ data: Results[]; loaded: boolean
     loaded={loaded}
     loadError={loadError}
     columns={columns}
-    Row={CnfCertificationSuiteRunRow}
+    Row={CertSuiteRunRow}
   />
 );
 
-const ResultsPage: React.FC<{ obj: CnfCertificationSuiteRun }> = ({ obj }) => {
+const ResultsPage: React.FC<{ obj: CertSuiteRun }> = ({ obj }) => {
   const { t } = useTranslation();
   const [activeFilter, setActiveFilter] = React.useState<string>('all'); // Default to showing all results
 
@@ -119,12 +119,12 @@ const ResultsPage: React.FC<{ obj: CnfCertificationSuiteRun }> = ({ obj }) => {
         onFilterChange={handleFilterChange}
       />
 
-      <ListPageHeader title={t('Cnf Certification Suite Run Results')} />
+      <ListPageHeader title={t('Certification Suite Run Results')} />
       <ListPageBody>
       {filteredResults.length === 0 ? (
           <div className="no-results">{t('No results found for the selected filter')}</div>
         ) : (
-          <CnfCertificationSuiteRunTable data={filteredResults} loaded loadError={null} />
+          <CertSuiteRunTable data={filteredResults} loaded loadError={null} />
         )}
       </ListPageBody>
     </>

--- a/src/components/SecretList.tsx
+++ b/src/components/SecretList.tsx
@@ -76,7 +76,7 @@ const ListSecret = ({namespace,name}) => {
 
   return (
     <>
-      <ListPageHeader title={t('plugin__certsuite-operator-plugin~CnfCertificationSuiteRun Secrets List')}>
+      <ListPageHeader title={t('plugin__certsuite-operator-plugin~CertSuiteRun Secrets List')}>
       <ListPageCreate groupVersionKind={{version: 'v1', kind: 'Secret' }}>
           {t('plugin__certsuite-operator-plugin~Create a Secret')}
         </ListPageCreate> 

--- a/src/components/plugin.ts
+++ b/src/components/plugin.ts
@@ -1,8 +1,8 @@
 // src/plugin.ts
 import ResultsPage from './ResultsPage';
-import CnfCertsuiteRunPage from './CnfCertsuiteRunPage';
+import CertsuiteRunPage from './CertsuiteRunPage';
 
 export const plugin = {
-  cnfCertsuiteRunPage: CnfCertsuiteRunPage,
+  CertsuiteRunPage: CertsuiteRunPage,
   resultsPage: ResultsPage,
 };


### PR DESCRIPTION
This PR changes the certification run CRD name, domain and api group according to the name changes in the operator (see changes [here](https://github.com/redhat-best-practices-for-k8s/certsuite-operator/pull/121))

See [note](https://github.com/redhat-best-practices-for-k8s/certsuite-operator-plugin/pull/7) in previous PR.